### PR TITLE
修复Linux下文件及文件夹相对路径问题，部分路径更改为绝对路径。

### DIFF
--- a/main/maingui.cpp
+++ b/main/maingui.cpp
@@ -4,6 +4,8 @@
 
 #include "Interface.h"
 
+#include <QDebug>
+
 Interface::Interface(QWidget* parent): QWidget(parent)
 {
 #if __WIN32
@@ -20,7 +22,12 @@ Interface::Interface(QWidget* parent): QWidget(parent)
 #endif
 
 	root_path = QDir::currentPath();
-	root_path = root_path.left(root_path.size() - 4);
+
+    // Change the way of getting ROOT_PATH
+    // Edited by Skykey
+    //root_path = root_path.left(root_path.size() - 4);
+    root_path = root_path.mid(0,root_path.lastIndexOf('/'));
+
 	font = QFont("Microsoft YaHei", 9, QFont::Normal);
 	setFont(font);
 	vbox = new QVBoxLayout(this);
@@ -940,12 +947,18 @@ void Interface::set_to_English()
 
 void Interface::open_manual_Chinese()
 {
-	 QDesktopServices::openUrl(QUrl("file:./guide/智弦（SmartChordGen）用户手册.pdf"));
+    // Fixed fileUrl error on linux
+    // Edited by Skykey
+    //QDesktopServices::openUrl(QUrl("file:./guide/智弦（SmartChordGen）用户手册.pdf"));
+    QDesktopServices::openUrl(QUrl(tr("file:%1/bin/guide/智弦（SmartChordGen）用户手册.pdf").arg(root_path)));
 }
 
 void Interface::open_manual_English()
 {
-	 QDesktopServices::openUrl(QUrl("file:./guide/SmartChordGen User Guide.pdf"));
+    // Fixed fileUrl error on linux
+    // Edited by Skykey
+    //QDesktopServices::openUrl(QUrl("file:./guide/SmartChordGen User Guide.pdf"));
+    QDesktopServices::openUrl(QUrl(tr("file:%1/bin/guide/SmartChordGen User Guide.pdf").arg(root_path)));
 }
 
 void Interface::set_output_name()
@@ -1367,7 +1380,10 @@ void Interface::set_remove_dup_type(int state)
 
 void Interface::open_utilities()
 {
-    QDesktopServices::openUrl(QUrl("file:../utilities"));
+    // Fixed fileUrl error on linux
+    // Edited by Skykey
+    //QDesktopServices::openUrl(QUrl("file:../utilities"));
+    QDesktopServices::openUrl(QUrl(tr("file:%1/utilities").arg(root_path)));
 }
 
 void Interface::run()

--- a/main/maingui.cpp
+++ b/main/maingui.cpp
@@ -4,8 +4,6 @@
 
 #include "Interface.h"
 
-#include <QDebug>
-
 Interface::Interface(QWidget* parent): QWidget(parent)
 {
 #if __WIN32


### PR DESCRIPTION
经验证后，Linux下使用程序中设定的相对路径无法打开文件及文件夹（例如/bin/guide目录下的PDF文档），我试着做了如下更改并验证这些更改的确生效：
* 更改root_path获取方式。
* 更改部分 QDesktopServices QUrl路径（采用绝对路径）。
```
//root_path = root_path.left(root_path.size() - 4);
root_path = root_path.mid(0,root_path.lastIndexOf('/'));
...
//QDesktopServices::openUrl(QUrl("file:../utilities"));
QDesktopServices::openUrl(QUrl(tr("file:%1/utilities").arg(root_path)));
```