### PR TITLE
fix: call set_notes after QLineEdit edit_initial is initialized

### DIFF
--- a/main/maingui.cpp
+++ b/main/maingui.cpp
@@ -894,11 +894,6 @@ void Interface::read_preset(char* filename)
 
 	read_data(fin, str);
 	automatic = (strcmp(str, "automatic") == 0);
-	if(!automatic)
-	{
-		read_data(fin, str_notes);
-		set_notes(notes, edit_initial);
-	}
 	connect_pedal = read_data(fin, str);
 	interlace = read_data(fin, str);
 	read_data(fin, str);
@@ -1044,6 +1039,12 @@ void Interface::read_preset(char* filename)
 	if(language == Chinese)
 		set_to_Chinese();
 	else  set_to_English();
+
+	if(!automatic)
+	{
+		read_data(fin, str_notes);
+		set_notes(notes, edit_initial);
+	}
 }
 
 void Interface::set_to_Chinese()


### PR DESCRIPTION
We should call `set_notes` later (after calling `Interface::mainGui()`, otherwise `QString str_notes = edit -> text()` in `Interface::set_notes` would seg fault.